### PR TITLE
_narrow関数修正、CORBA_Objectのデータサイズ修正

### DIFF
--- a/include/RtORB/corba-object-defs.hh
+++ b/include/RtORB/corba-object-defs.hh
@@ -193,6 +193,10 @@ namespace CORBA {
      * @brief (TODO)
      */
     CORBA_boolean _non_existent();
+    /*!
+     * @brief (TODO)
+     */
+    virtual CORBA_boolean _is_a(const CORBA_char * id);
     
   };
 
@@ -374,7 +378,17 @@ public:
   static T * narrow(CORBA::Object_ptr ptr) {
     if (!ptr) { return NULL; }
     CORBA_Object impl = ptr.impl();
-    return new T(impl);
+    
+    T * obj = new T(impl);
+    return obj;
+    if(obj->_is_a((const CORBA_char *)T::_type_code()->repository_id))
+    { 
+      return obj;
+    }
+    else
+    {
+      return NULL;
+    }
   }
 };
 

--- a/lib/CXX/corba.cc
+++ b/lib/CXX/corba.cc
@@ -168,6 +168,19 @@ namespace CORBA{
     if(!_impl) return TRUE;
     return CORBA_Object_non_existent(_impl, &env);
   }
+  
+  
+  CORBA_boolean Object::_is_a(const CORBA_char * id)
+  {
+    CORBA_Environment env;
+    CORBA_Object tmp = _impl;
+    if(!_impl) return TRUE;
+    CORBA_char* id_ = RtORB__strdup(id, "Object::_is_a():id");
+    CORBA_boolean ret = CORBA_Object_is_a(_impl, (unsigned char*)id_, &env);
+    RtORB_free(id_, "Object::_is_a():id");
+    return ret;
+  }
+  
 
   /* #############################################
    *

--- a/lib/allocater.c
+++ b/lib/allocater.c
@@ -296,7 +296,15 @@ RtORB_free_by_typecode_cpp(CORBA_TypeCode tc, void *val, int32_t flag){
 
 	   for(i=0;i< tc->member_count;i++){
              _tc = tc->member_type[i];
-	     tc_size = size_of_typecode(_tc, F_DEMARSHAL);
+	     
+	     if(_tc->kind == tk_objref)
+             {
+               tc_size = sizeof(void *);
+             }
+             else
+             {
+	       tc_size = size_of_typecode(_tc, F_DEMARSHAL);
+	     }
              Address_Alignment(&align, align_of_typecode(_tc, F_DEMARSHAL));
 	     tmp = (char *)val + align;
              RtORB_free_by_typecode_cpp(_tc, tmp, 0);

--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -1203,7 +1203,7 @@ int marshal_by_typecode(octet *buf, void *argv, CORBA_TypeCode tc, int *current)
        if (tc_ == NULL) { tc_ = CORBA_TypeCode_get(tk_null); }
           Address_Alignment(current, 4);
 
-         if (tc->kind != tk_except)
+         if (tc_->kind != tk_except)
          {
            marshal_typecode(buf, current, tc_);
          }

--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -637,6 +637,7 @@ demarshal_by_typecode(void **dist, CORBA_TypeCode tc, octet *buf, int *current, 
         } else {
           *current += len;
         }
+        Address_Alignment(current, 4);
       }
       break;
 
@@ -1202,16 +1203,15 @@ int marshal_by_typecode(octet *buf, void *argv, CORBA_TypeCode tc, int *current)
 
        if (tc_ == NULL) { tc_ = CORBA_TypeCode_get(tk_null); }
           Address_Alignment(current, 4);
-
-         if (tc_->kind != tk_except)
-         {
-           marshal_typecode(buf, current, tc_);
-         }
 #if 0
           marshalLong(buf, current, any->_len);
 #endif
          int32_t len;
          char *v = CORBA_any_get_encoded(any, &len);
+         if (tc_->kind != tk_except)
+         {
+           marshal_typecode(buf, current, tc_);
+         }
          if (v) {
            memcpy(&buf[*current], v, len); *current += len;
          } else {

--- a/lib/giop-marshal.c
+++ b/lib/giop-marshal.c
@@ -137,7 +137,14 @@ uint32_t size_of_typecode(CORBA_TypeCode tc, int flag)
 */
        for(i=0, size=0; i<tc->member_count;i++){
            Address_Alignment(&size, align_of_typecode(tc->member_type[i], flag));
-           size += size_of_typecode(tc->member_type[i], flag);
+           if(flag == F_DEMARSHAL && tc->member_type[i]->kind == tk_objref)
+           {
+             size += sizeof(void *);
+           }
+           else
+           {
+             size += size_of_typecode(tc->member_type[i], flag);
+           }
            if (i == (tc->member_count - 1)) {
                Address_Alignment(&size, align_of_typecode(tc, flag)); /* Last padding */
            }
@@ -152,7 +159,7 @@ uint32_t size_of_typecode(CORBA_TypeCode tc, int flag)
        size += size_of_typecode(tc->discriminator, flag);
        return size;
     case tk_objref:
-       return sizeof(CORBA_Object);
+       return sizeof(CORBA_Object_struct);
 
     case tk_string:
       if(flag == F_MARSHAL) return 4;
@@ -630,6 +637,7 @@ demarshal_by_typecode(void **dist, CORBA_TypeCode tc, octet *buf, int *current, 
 
     case tk_string:
       {
+        Address_Alignment(current, 4);
         len = demarshalLong(buf, current, order);
         if (dist) {
           *dist = (void *)RtORB_alloc(len, "demarshal_by_typecode(string)");
@@ -637,7 +645,6 @@ demarshal_by_typecode(void **dist, CORBA_TypeCode tc, octet *buf, int *current, 
         } else {
           *current += len;
         }
-        Address_Alignment(current, 4);
       }
       break;
 
@@ -1131,7 +1138,15 @@ int marshal_by_typecode(octet *buf, void *argv, CORBA_TypeCode tc, int *current)
           _buffer = (void **)((char *)argv + cpos);
 
           marshal_by_typecode(buf, _buffer, ctc, current);
-          cpos = cpos + size_of_typecode(ctc, F_DEMARSHAL);
+          
+          if(ctc->kind == tk_objref)
+          {
+            cpos = cpos + sizeof(void *);
+          }
+          else
+          {
+            cpos = cpos + size_of_typecode(ctc, F_DEMARSHAL);
+          }
         }
       }
       break;

--- a/lib/orb.c
+++ b/lib/orb.c
@@ -618,15 +618,40 @@ CORBA_Object_is_a(CORBA_Object object,
 		unsigned char *logical_type_id,
 		CORBA_Environment *env)
 {
+  /*
   if(!strcmp((char *)object->repository_id, (const char *)logical_type_id)) return TRUE;
   if(!strcmp((char *)logical_type_id, "IDL:omg.org/CORBA/Object:1.0")) return TRUE;
   return FALSE;
+  */
+  void *_args[1];
+  _args[0] = (void *) &logical_type_id;
+  CORBA_IArg _is_a_arginfo[] = {
+     {TC_CORBA_string, CORBA_I_ARG_IN, "logical_type_id"}
+  };
+  CORBA_Class_Method method = {
+      "_is_a",
+      TC_CORBA_boolean,
+      1, _is_a_arginfo,
+      0, NULL};
+  CORBA_boolean _ORBIT_retval;
+  invokeMethod (object, &method, (void **)&_ORBIT_retval, _args, env );
+  return _ORBIT_retval;
 }
 
 boolean
 CORBA_Object_non_existent(CORBA_Object object, CORBA_Environment *env){
-  if(object->ref == 0) return FALSE;
-  return TRUE;
+  //if(object->ref == 0) return FALSE;
+  //return TRUE;
+  CORBA_IArg _non_existent__arginfo[] = {
+  };
+  CORBA_Class_Method method = {
+      "_non_existent",
+      TC_CORBA_boolean,
+      0, _non_existent__arginfo,
+      0, NULL};
+  CORBA_boolean _ORBIT_retval;
+  invokeMethod (object, &method, (void **)&_ORBIT_retval, NULL, env );
+  return _ORBIT_retval;
 }
 
 uint32_t

--- a/lib/poa.c
+++ b/lib/poa.c
@@ -651,6 +651,7 @@ PortableServer_ServantBase__is_a(PortableServer_Servant servant, const char *id,
   if(!strcmp(id, info->class_name)) return TRUE;
 
   clsimpl = info->class_impl;
+  if(!strcmp(id, clsimpl->tc->repository_id)) return TRUE;
   for (i=0; i<clsimpl->n_base_types; i++) {
 #ifdef DEBUG
     fprintf(stderr, "\tinherited from %s\n", clsimpl->base_types[i]);

--- a/lib/rtorb.c
+++ b/lib/rtorb.c
@@ -110,7 +110,9 @@ void invokeMethod_via_GIOP(CORBA_Object obj,
      if(arg_buf){ RtORB_free(arg_buf,"invokeMethod_via_GIOP(arg_buf)"); }
       if(req_buf){ RtORB_free(req_buf,"invokeMethod_via_GIOP(req_buf)"); }
       if(buf){ RtORB_free(buf,"invokeMethod_via_GIOP(buf)"); }
-      exit(1);
+      env->_major = CORBA_SYSTEM_EXCEPTION;
+      //exit(1);
+      return;
   }
 
   /* check location */
@@ -300,5 +302,20 @@ void invokeMethod(CORBA_Object obj,
   info = (PortableServer_ClassInfo *)poa_obj->_private;
   PortableServer_ServantBase *sb = (PortableServer_ServantBase*)poa_obj->servant;
   call_impl_func = (impl_func_type)(*info->impl_finder)(&sb->_private, method->name, &m_data, &impl_method );
+  if (!call_impl_func){
+      
+      if(!strcmp(method->name, "_is_a") && sb->vepv && sb->vepv[0]->is_a ){
+	  *(CORBA_boolean*)retval = (void*)(sb->vepv[0]->is_a)(&sb->_private, *(char **)(args[0]) , env );
+	  return;
+      }
+      else if(!strcmp(method->name, "_non_existent") && sb->vepv && sb->vepv[0]->non_existent ){
+	  *(CORBA_boolean*)retval = (void*)(sb->vepv[0]->non_existent)(&sb->_private, env );
+	  return;
+      }
+      else{
+        fprintf(stderr, "No such a Function: %s\n", method->name);
+        return;
+      }
+  }
   (*call_impl_func)(sb, retval, m_data, args, env, impl_method);
 }

--- a/lib/util.c
+++ b/lib/util.c
@@ -280,7 +280,11 @@ void dump_value_by_typecode(void *val, CORBA_TypeCode tc){
     case tk_sequence:
        fprintf(stderr, "Sequence found --0x%x ---\n", val);
        fprintf(stderr, "  len=%d ---\n", ((CORBA_SequenceBase *)val)->_length);
-       dump_value_by_typecode(((CORBA_SequenceBase *)val)->_buffer, tc->member_type[i]);
+       for(i=0;i<((CORBA_SequenceBase *)val)->_length;i++){
+           fprintf(stderr, "address val = %x\n", (int)val);
+           dump_value_by_typecode(((CORBA_SequenceBase *)val)->_buffer, tc->member_type[i]);
+           val += size_of_typecode(tc->member_type[i], F_DEMARSHAL);
+       }
        fprintf(stderr, "==== Sequence\n");
        break;
     case tk_except:


### PR DESCRIPTION
以下の問題を修正した。

- `_narrow`関数内で`_is_a`関数を呼んで変換可能かを正常に判定できるようにしたが、シングルスレッドのRtORBでは何らかの操作を呼び出した先で、呼び出し元のオブジェクトの`_is_a`関数を呼ぶとデッドロックするため、以前と同じく機能しないようにしている
- ソースコード上で定義している構造体ではCORBA_ObjectはCORBA_Object_struct*型で定義されており、8byteのデータとなっている。まず、CORBA_Object型を初期化する時に8byteのポインタのサイズの領域を確保して初期化するが、これは間違いなのでCORBA_Object_struct型のサイズで初期化するように修正した。シリアライズする時には構造体からCORBA_Object型(8byte)を取得する必要があるが、CORBA_Object_struct型のサイズで取得してしまうため修正した。
- 通信でエラーが発生した場合に、`exit(1)`で終了しようとするが、例外を設定するように変更した。