### PR TITLE
メモリ解放エラーの対処

### DIFF
--- a/lib/allocater.c
+++ b/lib/allocater.c
@@ -321,7 +321,7 @@ RtORB_free_by_typecode_cpp(CORBA_TypeCode tc, void *val, int32_t flag){
 	 break;
   }
   if(flag){
-     RtORB_free(val, "RtORB_free_by_typecode_cpp");
+     //RtORB_free(val, "RtORB_free_by_typecode_cpp");
   }
   return;
 }

--- a/lib/giop-msg.c
+++ b/lib/giop-msg.c
@@ -71,7 +71,7 @@ void delete_CORBA_Sequence_Octet(CORBA_Sequence_Octet *seq, int flag){
     RtORB_free(seq->_buffer, "delete_CORBA_Sequence_Octet(buffer)");
   }
   if (flag){
-    RtORB_free(seq, "delete_CORBA_Sequence_Octet");
+    //RtORB_free(seq, "delete_CORBA_Sequence_Octet");
   }
 }
 
@@ -80,7 +80,7 @@ void delete_CORBA_Sequence_Octet2(CORBA_Sequence_Octet *seq, int flag){
     RtORB_free(seq->_buffer, "delete_CORBA_Sequence_Octet(buffer)");
   }
   if (flag){
-    RtORB_free(seq, "delete_CORBA_Sequence_Octet(seq)");
+    //RtORB_free(seq, "delete_CORBA_Sequence_Octet(seq)");
   }
 }
 


### PR DESCRIPTION
C++のnewで確保した領域をCのfreeで解放しようとして異常が発生する場合があるのを、一応落ちないように変更した。